### PR TITLE
Hacking script hooks

### DIFF
--- a/addons/hacking/functions/fnc_disconnect.sqf
+++ b/addons/hacking/functions/fnc_disconnect.sqf
@@ -33,3 +33,4 @@ private _interactDisconnect = (str _obj + "_disconnect");
 private _interactConnect = (str _obj + "_connect");
 [_obj, 0, ["ACE_MainActions", _interactDisconnect]] call ace_interact_menu_fnc_removeActionFromObject;
 [_obj, 0, ["ACE_MainActions", _interactConnect]] call ace_interact_menu_fnc_removeActionFromObject;
+_obj setVariable [QGVAR(hasInteract), false];

--- a/addons/hacking/functions/fnc_startHack.sqf
+++ b/addons/hacking/functions/fnc_startHack.sqf
@@ -37,8 +37,25 @@ private _duration = _obj getVariable [QGVAR(duration), 1];
 [
     {
         params ["_player", "_obj", "_laptop"];
+        // Cleanup
         _laptop setVariable [QGVAR(isHacking), nil, true];
         _laptop setVariable [QGVAR(object), nil, true];
+
+        // Ensure object is still connected to laptop
+        private _objConnected = _obj getVariable [QGVAR(connected), nil];
+        if (isNil "_objConnected") exitWith {};
+        if (_objConnected isNotEqualTo _laptop) exitWith{};
+
+        // Server event for hooks
+        [QGVAR(hackingCompleteServer), [_player, _obj, _laptop]] call CBA_fnc_serverEvent;
+
+        // Local event for hooks
+        [QGVAR(hackingCompletePlayer), [_player, _obj, _laptop], _player] call CBA_fnc_targetEvent;
+
+        // GlobalJIP event for hooks
+        [QGVAR(hackingCompleteGlobalJIP), [_player, _obj, _laptop]] call CBA_fnc_globalEventJIP;
+
+        // Handle intel sharing
         [_player, _obj] call FUNC(foundIntel);
     },
     [_player, _obj, _laptop],


### PR DESCRIPTION
**When merged this pull request will:**
- Add separate Server, Client, and GlobalJIP events for mission makers to hook into for custom implementations.
- Fix being unable to connect to a device after disconnecting

Example event handlers:
```sqf
// Server handler
["jsoc_ew_hacking_hackingCompleteServer", {
    params ["_player", "_object", "_laptop"];
    // Do something here
}] call CBA_fnc_addEventHandler;

// Player handler
// Local to EWO who did the hacking
["jsoc_ew_hacking_hackingCompletePlayer", {
    params ["_player", "_object", "_laptop"];
    // Do something here
}] call CBA_fnc_addEventHandler;

// Global handler
["jsoc_ew_hacking_hackingCompleteGlobalJIP", {
    params ["_player", "_object", "_laptop"];
    // Do something here
}] call CBA_fnc_addEventHandler;
```
